### PR TITLE
Correct using assumptions in vite-plugin-legacy patch

### DIFF
--- a/patches/@vitejs__plugin-legacy.patch
+++ b/patches/@vitejs__plugin-legacy.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.cjs b/dist/index.cjs
-index e8a593a533ca14c65a60360e64fb3d62e83778db..6b93be3efa4ab47c3eed2ce2f9d04418971e9115 100644
+index e8a593a533ca14c65a60360e64fb3d62e83778db..f818e17620d4debc6a5be8f8ca6b6b5c31bcf107 100644
 --- a/dist/index.cjs
 +++ b/dist/index.cjs
 @@ -164,7 +164,7 @@ function joinUrlSegments(a, b) {
@@ -41,18 +41,15 @@ index e8a593a533ca14c65a60360e64fb3d62e83778db..6b93be3efa4ab47c3eed2ce2f9d04418
          }
          const ms = new MagicString__default(raw);
          if (genLegacy && chunk.isEntry) {
-@@ -510,7 +517,9 @@ function viteLegacyPlugin(options = {}) {
-           ],
-           [
-             (await import('@babel/preset-env')).default,
--            createBabelPresetEnvOptions(targets, { needPolyfills })
-+            createBabelPresetEnvOptions(targets, assumptions, {
-+              needPolyfills
-+            })
-           ]
-         ]
-       });
-@@ -649,7 +658,7 @@ function viteLegacyPlugin(options = {}) {
+@@ -496,6 +503,7 @@ function viteLegacyPlugin(options = {}) {
+         compact: !!config.build.minify,
+         sourceMaps,
+         inputSourceMap: void 0,
++        assumptions,
+         presets: [
+           // forcing our plugin to run before preset-env by wrapping it in a
+           // preset so we can catch the injected import statements...
+@@ -649,13 +657,14 @@ function viteLegacyPlugin(options = {}) {
    };
    return [legacyConfigPlugin, legacyGenerateBundlePlugin, legacyPostPlugin];
  }
@@ -61,35 +58,14 @@ index e8a593a533ca14c65a60360e64fb3d62e83778db..6b93be3efa4ab47c3eed2ce2f9d04418
    const babel2 = await loadBabel();
    const result = babel2.transform(code, {
      ast: true,
-@@ -659,7 +668,7 @@ async function detectPolyfills(code, targets, list) {
+     babelrc: false,
+     configFile: false,
+     compact: false,
++    assumptions,
      presets: [
        [
          (await import('@babel/preset-env')).default,
--        createBabelPresetEnvOptions(targets, {})
-+        createBabelPresetEnvOptions(targets, assumptions, {})
-       ]
-     ]
-   });
-@@ -672,7 +681,7 @@ async function detectPolyfills(code, targets, list) {
-     }
-   }
- }
--function createBabelPresetEnvOptions(targets, { needPolyfills = true }) {
-+function createBabelPresetEnvOptions(targets, assumptions, { needPolyfills = true }) {
-   return {
-     targets,
-     bugfixes: true,
-@@ -684,7 +693,8 @@ function createBabelPresetEnvOptions(targets, { needPolyfills = true }) {
-       proposals: false
-     } : void 0,
-     shippedProposals: true,
--    ignoreBrowserslistConfig: true
-+    ignoreBrowserslistConfig: true,
-+    assumptions
-   };
- }
- async function buildPolyfillChunk(mode, imports, bundle, facadeToChunkMap, buildOptions, format, rollupOutputOptions, excludeSystemJS, prependModenChunkLegacyGuard) {
-@@ -712,7 +722,8 @@ async function buildPolyfillChunk(mode, imports, bundle, facadeToChunkMap, build
+@@ -712,7 +721,8 @@ async function buildPolyfillChunk(mode, imports, bundle, facadeToChunkMap, build
          output: {
            format,
            hashCharacters: rollupOutputOptions.hashCharacters,
@@ -170,7 +146,7 @@ index 3872f9aa9f22bd3f72c20f31b53296fea31db86c..f4adce20734c5bd272bcbb810fd200d8
 +export = viteLegacyPlugin;
 +export { type Options, cspHashes, detectPolyfills };
 diff --git a/dist/index.mjs b/dist/index.mjs
-index e06d4a9fcb81500735f1d550447ffa07095853d5..38ecbb634a2f161eb925fc60038267c7055596b0 100644
+index e06d4a9fcb81500735f1d550447ffa07095853d5..ef479a91fbfb33a47b071c3341779fd7da858cc4 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
 @@ -152,7 +152,7 @@ function joinUrlSegments(a, b) {
@@ -212,18 +188,15 @@ index e06d4a9fcb81500735f1d550447ffa07095853d5..38ecbb634a2f161eb925fc60038267c7
          }
          const ms = new MagicString(raw);
          if (genLegacy && chunk.isEntry) {
-@@ -498,7 +505,9 @@ function viteLegacyPlugin(options = {}) {
-           ],
-           [
-             (await import('@babel/preset-env')).default,
--            createBabelPresetEnvOptions(targets, { needPolyfills })
-+            createBabelPresetEnvOptions(targets, assumptions, {
-+              needPolyfills
-+            })
-           ]
-         ]
-       });
-@@ -637,7 +646,7 @@ function viteLegacyPlugin(options = {}) {
+@@ -484,6 +491,7 @@ function viteLegacyPlugin(options = {}) {
+         compact: !!config.build.minify,
+         sourceMaps,
+         inputSourceMap: void 0,
++        assumptions,
+         presets: [
+           // forcing our plugin to run before preset-env by wrapping it in a
+           // preset so we can catch the injected import statements...
+@@ -637,13 +645,14 @@ function viteLegacyPlugin(options = {}) {
    };
    return [legacyConfigPlugin, legacyGenerateBundlePlugin, legacyPostPlugin];
  }
@@ -232,35 +205,14 @@ index e06d4a9fcb81500735f1d550447ffa07095853d5..38ecbb634a2f161eb925fc60038267c7
    const babel2 = await loadBabel();
    const result = babel2.transform(code, {
      ast: true,
-@@ -647,7 +656,7 @@ async function detectPolyfills(code, targets, list) {
+     babelrc: false,
+     configFile: false,
+     compact: false,
++    assumptions,
      presets: [
        [
          (await import('@babel/preset-env')).default,
--        createBabelPresetEnvOptions(targets, {})
-+        createBabelPresetEnvOptions(targets, assumptions, {})
-       ]
-     ]
-   });
-@@ -660,7 +669,7 @@ async function detectPolyfills(code, targets, list) {
-     }
-   }
- }
--function createBabelPresetEnvOptions(targets, { needPolyfills = true }) {
-+function createBabelPresetEnvOptions(targets, assumptions, { needPolyfills = true }) {
-   return {
-     targets,
-     bugfixes: true,
-@@ -672,7 +681,8 @@ function createBabelPresetEnvOptions(targets, { needPolyfills = true }) {
-       proposals: false
-     } : void 0,
-     shippedProposals: true,
--    ignoreBrowserslistConfig: true
-+    ignoreBrowserslistConfig: true,
-+    assumptions
-   };
- }
- async function buildPolyfillChunk(mode, imports, bundle, facadeToChunkMap, buildOptions, format, rollupOutputOptions, excludeSystemJS, prependModenChunkLegacyGuard) {
-@@ -700,7 +710,8 @@ async function buildPolyfillChunk(mode, imports, bundle, facadeToChunkMap, build
+@@ -700,7 +709,8 @@ async function buildPolyfillChunk(mode, imports, bundle, facadeToChunkMap, build
          output: {
            format,
            hashCharacters: rollupOutputOptions.hashCharacters,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ patchedDependencies:
     hash: f7bb4a418fb6efb9a659bd0022fdb925bdd84911bd53efe26e1ba4016a1d8615
     path: patches/@solidjs__router.patch
   '@vitejs/plugin-legacy':
-    hash: cb997343403d8fc82ade2ce00cb9e481bb21498ccddef4d8301fee97c849cbc4
+    hash: e607e73fda2e2b6b5e0ac985fe7e9bf9064bc83e7a3ba4dcd95a3afa8e1f06a2
     path: patches/@vitejs__plugin-legacy.patch
 
 importers:
@@ -75,7 +75,7 @@ importers:
         version: 1.1.0(terser@5.39.0)
       '@vitejs/plugin-legacy':
         specifier: ^6.0.2
-        version: 6.0.2(patch_hash=cb997343403d8fc82ade2ce00cb9e481bb21498ccddef4d8301fee97c849cbc4)(terser@5.39.0)(vite@6.2.2(terser@5.39.0)(yaml@2.7.0))
+        version: 6.0.2(patch_hash=e607e73fda2e2b6b5e0ac985fe7e9bf9064bc83e7a3ba4dcd95a3afa8e1f06a2)(terser@5.39.0)(vite@6.2.2(terser@5.39.0)(yaml@2.7.0))
       gh-pages:
         specifier: ^6.3.0
         version: 6.3.0
@@ -3393,7 +3393,7 @@ snapshots:
 
   '@types/estree@1.0.6': {}
 
-  '@vitejs/plugin-legacy@6.0.2(patch_hash=cb997343403d8fc82ade2ce00cb9e481bb21498ccddef4d8301fee97c849cbc4)(terser@5.39.0)(vite@6.2.2(terser@5.39.0)(yaml@2.7.0))':
+  '@vitejs/plugin-legacy@6.0.2(patch_hash=e607e73fda2e2b6b5e0ac985fe7e9bf9064bc83e7a3ba4dcd95a3afa8e1f06a2)(terser@5.39.0)(vite@6.2.2(terser@5.39.0)(yaml@2.7.0))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)


### PR DESCRIPTION
Corrects patch added in #7 to pass assumptions to top level option in babel.transform