### PR TITLE
Add Suspense page and custom suspense component

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -154,6 +154,7 @@ render(() => (
     <Route path="flexgrow" component={FlexGrowPage} />
     <Route path="superflex" component={SuperFlexPage} />
     <Route path="keepalive" component={lazy(() => import('./pages/KeepAlive.jsx'))} />
+    <Route path="suspense" component={lazy(() => import('./pages/suspense.jsx'))} />
     <Route path="buttonsmaterial" component={ButtonsMaterialPage} />
     <Route path="entity/people/:id" component={People} />
     <Route path="entity/:type/:id" component={Entity} preload={entityPreload} />

--- a/src/pages/Portal.tsx
+++ b/src/pages/Portal.tsx
@@ -155,6 +155,11 @@ const Portal = () => {
       id: "keepalive",
       description: "Reuse component between layouts",
     },
+    {
+      title: "Suspense",
+      id: "suspense",
+      description: "Using Suspense to load data",
+    },
   ];
 
   function DemoTile(props) {

--- a/src/pages/suspense.tsx
+++ b/src/pages/suspense.tsx
@@ -2,6 +2,27 @@ import * as s from "solid-js";
 import * as lng from "@lightningtv/solid";
 import {setGlobalBackground} from "../state";
 
+function Suspense(props: {
+  fallback?: s.JSX.Element;
+  children: s.JSX.Element;
+}): s.JSX.Element {
+  
+  let children: s.JSX.Element;
+
+  let suspense = s.children(() => s.createComponent(s.Suspense, {
+    get children() {
+      return children = s.children(() => props.children) as any
+    },
+  }))
+
+  return <>
+    {suspense() ?? props.fallback}
+    <view hidden>
+      {suspense() ? null : children}
+    </view>
+  </>
+}
+
 function fadeIn(el: lng.ElementNode) {
   el.alpha = 0;
   el
@@ -26,13 +47,9 @@ export default function SuspensePage() {
     return "Hello World" + '!'.repeat(++lastCount);
   })
 
-  s.createEffect(() => {
-    console.log("data", data());
-  })
-
   return <>
     <view forwardFocus={0}>
-      <lng.Suspense fallback={<>
+      <Suspense fallback={<>
         <view
           onCreate={fadeIn}
           onDestroy={fadeOut}
@@ -49,10 +66,28 @@ export default function SuspensePage() {
           onEnter={() => {refetch()}}
           display="flex"
           center
+          ref={() => {
+
+            // Count will persist even after refetch
+            const [count, setCount] = s.createSignal(0);
+
+            s.onMount(() => {
+              const interval = setInterval(() => {
+                setCount(prev => prev + 1);
+              }, 100);
+          
+              s.onCleanup(() => clearInterval(interval));
+            });
+
+            // This effect will be suspensed when the data is loading
+            s.createEffect(() => {
+              console.log("count", count());
+            })
+          }}
         >
           <text>{data()}</text>
         </view>
-      </lng.Suspense>
+      </Suspense>
     </view>
   </>
 };

--- a/src/pages/suspense.tsx
+++ b/src/pages/suspense.tsx
@@ -2,6 +2,23 @@ import * as s from "solid-js";
 import * as lng from "@lightningtv/solid";
 import {setGlobalBackground} from "../state";
 
+/**
+ * Tracks all resources inside a component and renders a fallback until they are all resolved.
+ * 
+ * ```tsx
+ * const [data] = createResource(async () => ...);
+ *
+ * <Suspense fallback={<LoadingIndicator />}>
+ *   <view>
+ *     <text>{data()}</text>
+ *   </view>
+ * </Suspense>
+ * ```
+ * 
+ * This is a modified version of the SolidJS Suspense component that works with Lightning.
+ * 
+ * @see https://docs.solidjs.com/reference/components/suspense
+ */
 function Suspense(props: {
   fallback?: s.JSX.Element;
   children: s.JSX.Element;
@@ -9,11 +26,11 @@ function Suspense(props: {
   
   let children: s.JSX.Element;
 
-  let suspense = s.children(() => s.createComponent(s.Suspense, {
+  let suspense = s.Suspense({
     get children() {
-      return children = s.children(() => props.children) as any
+      return [children = s.children(() => props.children) as any];
     },
-  }))
+  }) as any as () => s.JSX.Element;
 
   return <>
     {suspense() ?? props.fallback}
@@ -44,7 +61,7 @@ export default function SuspensePage() {
 
   const [data, {refetch}] = s.createResource(async () => {
     await new Promise(r => setTimeout(r, 1600));
-    return "Hello World" + '!'.repeat(++lastCount);
+    return ++lastCount
   })
 
   return <>
@@ -74,7 +91,7 @@ export default function SuspensePage() {
             s.onMount(() => {
               const interval = setInterval(() => {
                 setCount(prev => prev + 1);
-              }, 100);
+              }, 200);
           
               s.onCleanup(() => clearInterval(interval));
             });
@@ -85,7 +102,7 @@ export default function SuspensePage() {
             })
           }}
         >
-          <text>{data()}</text>
+          <text>Hello World{'!'.repeat(data() ?? 0)} (Press Enter to refetch)</text>
         </view>
       </Suspense>
     </view>

--- a/src/pages/suspense.tsx
+++ b/src/pages/suspense.tsx
@@ -1,0 +1,58 @@
+import * as s from "solid-js";
+import * as lng from "@lightningtv/solid";
+import {setGlobalBackground} from "../state";
+
+function fadeIn(el: lng.ElementNode) {
+  el.alpha = 0;
+  el
+    .animate({alpha: 1}, {duration: 250, easing: 'ease-in-out'})
+    .start();
+}
+function fadeOut(el: lng.ElementNode) {
+  return el
+    .animate({alpha: 0}, {duration: 250, easing: 'ease-in-out'})
+    .start()
+    .waitUntilStopped();
+}
+
+export default function SuspensePage() {
+
+  setGlobalBackground("#000000")
+
+  let lastCount = 0;
+
+  const [data, {refetch}] = s.createResource(async () => {
+    await new Promise(r => setTimeout(r, 1600));
+    return "Hello World" + '!'.repeat(++lastCount);
+  })
+
+  s.createEffect(() => {
+    console.log("data", data());
+  })
+
+  return <>
+    <view forwardFocus={0}>
+      <lng.Suspense fallback={<>
+        <view
+          onCreate={fadeIn}
+          onDestroy={fadeOut}
+          display="flex"
+          center
+        >
+          <text>Loading...</text>
+        </view>
+      </>}>
+        <view
+          autofocus
+          onCreate={fadeIn}
+          onDestroy={fadeOut}
+          onEnter={() => {refetch()}}
+          display="flex"
+          center
+        >
+          <text>{data()}</text>
+        </view>
+      </lng.Suspense>
+    </view>
+  </>
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,6 +16,7 @@ export default defineConfig({
       solid: {
         moduleName: "@lightningtv/solid",
         generate: "universal",
+        builtIns: [],
       },
     }),
     legacy({


### PR DESCRIPTION
This adds a custom Suspense component experiment that will render the children in a hidden view when the data is loading. Which does not require any changes to lightning/solid.