### PR TITLE
feat: add RendererVersions switcher page

### DIFF
--- a/src/components/NavDrawer/NavDrawer.tsx
+++ b/src/components/NavDrawer/NavDrawer.tsx
@@ -64,6 +64,7 @@ export default function NavDrawer(props) {
     if (useMatch(() => "/browse/tv")()) return 488;
     if (useMatch(() => "/examples")()) return 578;
     if (useMatch(() => "/benchmark")()) return 668;
+    if (useMatch(() => "/versions")()) return 758;
     return 308;
   });
 
@@ -144,6 +145,14 @@ export default function NavDrawer(props) {
           onEnter={() => handleNavigate("/benchmark")}
         >
           Benchmark
+        </NavButton>
+        <NavButton
+          icon="experiment"
+          iconColor={"#fff"}
+          announce={["Versions", "button"]}
+          onEnter={() => handleNavigate("/versions")}
+        >
+          Versions
         </NavButton>
       </Column>
       <View skipFocus ref={backdrop} style={styles.Gradient} />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -62,6 +62,7 @@ const MixedImagePerformance = lazy(() => import("./pages/MixedImagePerformance")
 const TextureCompressionPerformance = lazy(() => import("./pages/TextureCompressionPerformance"));
 const ComplexFlexPage = lazy(() => import("./pages/ComplexFlex"));
 const BenchmarkPage = lazy(() => import("./pages/Benchmark"));
+const RendererVersionsPage = lazy(() => import("./pages/RendererVersions"));
 
 let numImageWorkers = 4;
 const urlParams = new URLSearchParams(window.location.search);
@@ -192,6 +193,7 @@ render(() => (
         <Route path="texture-compression-performance" component={TextureCompressionPerformance} />
         <Route path="complexflex" component={ComplexFlexPage} />
         <Route path="benchmark" component={BenchmarkPage} preload={tmdbData} />
+        <Route path="versions" component={RendererVersionsPage} />
 
         <Route path="*all" component={NotFound} />
       </Route>

--- a/src/pages/RendererVersions.tsx
+++ b/src/pages/RendererVersions.tsx
@@ -1,0 +1,93 @@
+import { Text, View, IntrinsicNodeStyleProps, IntrinsicTextNodeStyleProps } from "@lightningtv/solid";
+import { createSignal, onMount } from "solid-js";
+import { setGlobalBackground } from "../state";
+
+const knownVersions = [300, 316, 320, 321, 322, 323, 324, 325, 326, 330, 331, 340];
+
+const RendererVersionsPage = () => {
+  const [version, setVersion] = createSignal(340);
+
+  onMount(() => {
+    setGlobalBackground("#000000");
+  });
+
+  const onRight = () => {
+    const current = version();
+    const index = knownVersions.indexOf(current);
+    if (index >= 0 && index < knownVersions.length - 1) {
+      setVersion(knownVersions[index + 1]);
+    } else {
+      setVersion(knownVersions[0]);
+    }
+    return true;
+  };
+
+  const onLeft = () => {
+    const current = version();
+    const index = knownVersions.indexOf(current);
+    if (index > 0) {
+      setVersion(knownVersions[index - 1]);
+    } else {
+      setVersion(knownVersions[0]);
+    }
+    return true;
+  };
+
+  const onUp = () => {
+    setVersion((v) => v + 1);
+    return true;
+  };
+
+  const onDown = () => {
+    setVersion((v) => Math.max(0, v - 1));
+    return true;
+  };
+
+  const onEnter = () => {
+    window.location.href = `https://lightning-tv.github.io/solid-demo-app/${version()}/#/benchmark`;
+    return true;
+  };
+
+  const Container = {
+    width: 1000,
+    height: 500,
+    x: 460,
+    y: 200,
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center"
+  } satisfies IntrinsicNodeStyleProps;
+
+  const Title = {
+    fontSize: 48,
+    fontWeight: "bold",
+    marginBottom: 40
+  } satisfies IntrinsicTextNodeStyleProps;
+
+  const VersionText = {
+    fontSize: 160,
+    fontWeight: "bold",
+    color: "#00E0FF",
+    marginBottom: 40
+  } satisfies IntrinsicTextNodeStyleProps;
+
+  const Instructions = {
+    fontSize: 28,
+    color: "#bbbbbb",
+    textAlign: "center",
+    lineHeight: 40,
+    marginBottom: 10
+  } satisfies IntrinsicTextNodeStyleProps;
+
+  return (
+    <View style={Container} autofocus onRight={onRight} onLeft={onLeft} onUp={onUp} onDown={onDown} onEnter={onEnter}>
+      <Text style={Title}>Renderer Version Switcher</Text>
+      <Text style={VersionText}>{version().toString()}</Text>
+      <Text style={Instructions}>Use LEFT / RIGHT arrows to select a known version</Text>
+      <Text style={Instructions}>Use UP / DOWN arrows to select a custom number</Text>
+      <Text style={Instructions}>Press ENTER to launch benchmark for this version</Text>
+    </View>
+  );
+};
+
+export default RendererVersionsPage;


### PR DESCRIPTION
For Some TVs is difficult to switch open custom URLs. In this way the tests of renderer versions will be faster. And QA people will have an easier life.

Thanks!